### PR TITLE
subscribable data analyzer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.0'
+	runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.76.Final:osx-aarch_64'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/template/template/ChargingPlugGatewaySubscribeRequestBodyDTO.java
+++ b/src/main/java/com/template/template/ChargingPlugGatewaySubscribeRequestBodyDTO.java
@@ -1,0 +1,12 @@
+package com.template.template;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChargingPlugGatewaySubscribeRequestBodyDTO {
+    private String path;
+    private String uri;
+    private ChargingPlugStationEventType eventType;
+}

--- a/src/main/java/com/template/template/ChargingPlugStationEventType.java
+++ b/src/main/java/com/template/template/ChargingPlugStationEventType.java
@@ -1,0 +1,15 @@
+package com.template.template;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ChargingPlugStationEventType {
+    DAILY("DAILY"),
+    LAST_STATUS("LAST_STATUS");
+
+    @JsonValue
+    private String label;
+
+    ChargingPlugStationEventType(final String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/com/template/template/Controller.java
+++ b/src/main/java/com/template/template/Controller.java
@@ -1,0 +1,25 @@
+package com.template.template;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.Serializable;
+
+@RestController("/")
+@Slf4j
+public class Controller {
+    @PostMapping("/daily-report")
+    private ResponseEntity<?> postChargingPlugDailyReport(final @RequestBody Object dailyReport) {
+        log.info("Received daily report: {}", dailyReport);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/current-status")
+    private ResponseEntity<?> postChargingPlugStationCurrentStatus(final @RequestBody String currentStatus) {
+        log.info("Received current status: {}", currentStatus);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/template/template/Subscriber.java
+++ b/src/main/java/com/template/template/Subscriber.java
@@ -1,0 +1,89 @@
+package com.template.template;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+public class Subscriber implements ApplicationRunner {
+    @Value("${number-of-clients}")
+    private Integer numberOfClients;
+
+    private final String gatewayPath = "http://localhost:8080";
+    private final String subscribeUri = "/subscribe";
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        for (int i = 0; i < numberOfClients; i++) {
+            subscribeDaily();
+            subscribeLastStatus();
+        }
+    }
+
+    private void subscribeDaily() {
+        log.info("Subscribing to daily report");
+        final var requestBody = ChargingPlugGatewaySubscribeRequestBodyDTO.builder()
+                .path("http://localhost:8081")
+                .uri("/daily-report")
+                .eventType(ChargingPlugStationEventType.DAILY)
+                .build();
+
+        WebClient.create(gatewayPath)
+                .post()
+                .uri(subscribeUri)
+                .accept(MediaType.ALL)
+                .bodyValue(requestBody)
+                .retrieve()
+                .onStatus(HttpStatusCode::is2xxSuccessful, clientResponse -> {
+                    log.info("Subscribing daily report success");
+                    return Mono.empty();
+                })
+                .onStatus(HttpStatusCode::isError, clientResponse -> {
+                    log.error("Error subscribing for daily report");
+                    return Mono.empty();
+                })
+                .bodyToMono(Void.class)
+                .onErrorResume(throwable -> {
+                    log.error("Error connecting to gateway", throwable);
+                    return Mono.empty();
+                })
+                .subscribe();
+    }
+
+    private void subscribeLastStatus() {
+        log.info("Subscribing to current status");
+        final var requestBody = ChargingPlugGatewaySubscribeRequestBodyDTO.builder()
+                .path("http://localhost:8081")
+                .uri("/current-status")
+                .eventType(ChargingPlugStationEventType.LAST_STATUS)
+                .build();
+
+        WebClient.create(gatewayPath)
+                .post()
+                .uri(subscribeUri)
+                .accept(MediaType.ALL)
+                .bodyValue(requestBody)
+                .retrieve()
+                .onStatus(HttpStatusCode::is2xxSuccessful, clientResponse -> {
+                    log.info("Subscribing current status success");
+                    return Mono.empty();
+                })
+                .onStatus(HttpStatusCode::isError, clientResponse -> {
+                    log.error("Error subscribing for current status");
+                    return Mono.empty();
+                })
+                .bodyToMono(Void.class)
+                .onErrorResume(throwable -> {
+                    log.error("Error connecting to gateway", throwable);
+                    return Mono.empty();
+                })
+                .subscribe();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=charging-plug-data-analyzer
 server.port=8081
+number-of-clients=${NUMBER_OF_CLIENTS:1}


### PR DESCRIPTION
This PR implements the data analyzer used to consume data from https://github.com/gfmota/charging-plug-gateway/pull/2

The analyzer receives the data from http requests. The setup necessary would be to subscribe each endpoint to the subscibable gateway, this can be done by requesting the `/subscribe` endpoint with the path, uri and data type wanted.